### PR TITLE
Add zero-yen Jimoty watcher tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
+# Jimoty Zero Yen Watcher
 
+ジモティーの全国新着「0円」投稿を素早く収集するための小さなツールセットです。HTTPクライアントで検索一覧を取得し、構造化データ（JSON-LD）やDOMを解析して投稿情報を抽出します。JSON キャッシュを使って「未読」のみを抽出することもできます。
+
+> **注意**: 実際のジモティーサイトはアクセス制限や利用規約があります。自動取得を行う前に最新の利用規約を必ず確認し、過剰なリクエストを避けてください。必要であれば User-Agent やアクセス間隔を調整してください。
+
+## 使い方
+
+### セットアップ
+
+任意ですが仮想環境を作成すると便利です。追加ライブラリは不要なので、標準ライブラリだけで実行できます。
+
+### CLI で最新 0 円投稿を取得
+
+```bash
+python -m jimoty_zero_yen.cli --pages 2 --cache data/cache.json --json
+```
+
+- `--pages`: 取得したいページ数（デフォルト 1）。
+- `--cache`: 指定すると、同じ投稿 ID を持つアイテムはスキップされます。
+- `--json`: JSON 形式で出力します。省略時は人間が読みやすいテキスト形式。
+
+### Python から利用
+
+```python
+from jimoty_zero_yen import JimotyClient
+
+client = JimotyClient()
+listings = client.fetch_zero_yen_listings(pages=1)
+for listing in listings:
+    print(listing.title, listing.url)
+```
+
+### AI 連携のヒント
+
+抽出した `Listing` オブジェクトはプレーンな Python データクラスです。例えば OpenAI API や埋め込みモデルに渡して要約・タグ付け・レコメンドといった AI 処理を追加することができます。`Listing` オブジェクトを辞書に変換するヘルパー関数 `_listing_to_dict` は CLI に含まれているので、同様の処理を参考にしてください。
+
+## テスト
+
+```bash
+python -m unittest discover
+```
+
+## ライセンス
+
+MIT

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# This project intentionally avoids third-party runtime dependencies.

--- a/src/jimoty_zero_yen/__init__.py
+++ b/src/jimoty_zero_yen/__init__.py
@@ -1,0 +1,8 @@
+"""Utilities for collecting zero-yen Jimoty listings."""
+
+from .cache import ListingCache
+from .client import JimotyClient
+from .models import Listing
+from .parser import JimotyParser
+
+__all__ = ["JimotyClient", "JimotyParser", "Listing", "ListingCache"]

--- a/src/jimoty_zero_yen/cache.py
+++ b/src/jimoty_zero_yen/cache.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Set
+
+from .models import Listing
+
+
+class ListingCache:
+    """Disk-backed cache that keeps track of seen listing identifiers."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self._ids: Set[str] = set()
+        self._load()
+
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            data = json.loads(self.path.read_text("utf-8"))
+        except json.JSONDecodeError:
+            data = []
+        if isinstance(data, list):
+            self._ids = {str(item) for item in data}
+
+    # ------------------------------------------------------------------
+    def _flush(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(sorted(self._ids)), encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    def seen(self, listing_id: str) -> bool:
+        return listing_id in self._ids
+
+    # ------------------------------------------------------------------
+    def mark_seen(self, listing: Listing) -> bool:
+        """Register a listing as seen and return True if it was new."""
+
+        is_new = listing.id not in self._ids
+        self._ids.add(listing.id)
+        self._flush()
+        return is_new
+
+    # ------------------------------------------------------------------
+    def filter_new(self, listings: Iterable[Listing]) -> list[Listing]:
+        """Return only the listings that have not been seen before."""
+
+        new_listings = []
+        for listing in listings:
+            if listing.id not in self._ids:
+                new_listings.append(listing)
+                self._ids.add(listing.id)
+        if new_listings:
+            self._flush()
+        return new_listings
+
+
+__all__ = ["ListingCache"]

--- a/src/jimoty_zero_yen/cli.py
+++ b/src/jimoty_zero_yen/cli.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import timezone
+from pathlib import Path
+from typing import Iterable
+
+from .cache import ListingCache
+from .client import JimotyClient
+from .models import Listing
+
+
+def _listing_to_dict(listing: Listing) -> dict:
+    data = {
+        "id": listing.id,
+        "title": listing.title,
+        "price": listing.price,
+        "url": listing.url,
+        "location": listing.location,
+        "thumbnail_url": listing.thumbnail_url,
+    }
+    if listing.posted_at:
+        data["posted_at"] = listing.posted_at.astimezone(timezone.utc).isoformat()
+    return data
+
+
+def collect_listings(pages: int, cache: ListingCache | None) -> list[Listing]:
+    client = JimotyClient()
+    listings = client.fetch_zero_yen_listings(pages=pages)
+    if cache:
+        return cache.filter_new(listings)
+    return listings
+
+
+def run_cli(args: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Collect new zero-yen listings from Jimoty")
+    parser.add_argument("--pages", type=int, default=1, help="Number of pages to fetch (default: 1)")
+    parser.add_argument("--cache", type=Path, help="Path to cache file that tracks seen listings")
+    parser.add_argument("--json", action="store_true", help="Output listings as JSON")
+
+    parsed = parser.parse_args(args=args)
+
+    cache = ListingCache(parsed.cache) if parsed.cache else None
+    listings = collect_listings(parsed.pages, cache)
+
+    if parsed.json:
+        payload = [_listing_to_dict(listing) for listing in listings]
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        for listing in listings:
+            print(f"[{listing.id}] {listing.title} ({listing.location or 'エリア不明'}) -> {listing.url}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    run_cli()

--- a/src/jimoty_zero_yen/client.py
+++ b/src/jimoty_zero_yen/client.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import logging
+from typing import Callable, List, Optional
+from urllib import error, request
+from urllib.parse import urlencode, urljoin
+
+from .models import Listing
+from .parser import JimotyParser
+
+LOGGER = logging.getLogger(__name__)
+
+
+class JimotyClient:
+    """HTTP client that fetches Jimoty listings without external dependencies."""
+
+    BASE_URL = "https://jmty.jp"
+    SEARCH_PATH = "/all/sale"
+    USER_AGENT = (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/126.0 Safari/537.36"
+    )
+
+    def __init__(
+        self,
+        parser: Optional[JimotyParser] = None,
+        timeout: int = 10,
+        fetcher: Optional[Callable[[str], Optional[str]]] = None,
+    ) -> None:
+        self.parser = parser or JimotyParser()
+        self.timeout = timeout
+        self._fetcher = fetcher
+
+    # ------------------------------------------------------------------
+    def fetch_zero_yen_listings(self, pages: int = 1) -> List[Listing]:
+        listings: List[Listing] = []
+        for page in range(1, max(pages, 1) + 1):
+            url = self._build_search_url(page=page)
+            html = self._fetch(url)
+            if not html:
+                break
+            page_listings = self.parser.parse_listings(html)
+            listings.extend(page_listings)
+            if not page_listings:
+                break
+        return listings
+
+    # ------------------------------------------------------------------
+    def _fetch(self, url: str) -> Optional[str]:
+        if self._fetcher:
+            return self._fetcher(url)
+
+        req = request.Request(url, headers={"User-Agent": self.USER_AGENT})
+        try:
+            with request.urlopen(req, timeout=self.timeout) as response:
+                encoding = response.headers.get_content_charset() or "utf-8"
+                return response.read().decode(encoding, errors="replace")
+        except (error.URLError, error.HTTPError) as exc:  # pragma: no cover - logging only
+            LOGGER.warning("Failed to fetch Jimoty listings: %s", exc)
+            return None
+
+    # ------------------------------------------------------------------
+    def _build_search_url(self, page: int = 1) -> str:
+        params = {
+            "price": 0,
+            "page": page,
+            "st": "new",
+        }
+        return urljoin(self.BASE_URL, f"{self.SEARCH_PATH}?{urlencode(params)}")
+
+
+__all__ = ["JimotyClient"]

--- a/src/jimoty_zero_yen/models.py
+++ b/src/jimoty_zero_yen/models.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass(frozen=True, slots=True)
+class Listing:
+    """Structured representation of a Jimoty listing."""
+
+    id: str
+    title: str
+    price: int
+    url: str
+    location: Optional[str] = None
+    posted_at: Optional[datetime] = None
+    thumbnail_url: Optional[str] = None
+
+    @property
+    def is_zero_yen(self) -> bool:
+        """Return True if the listing is advertised as free."""
+
+        return self.price == 0
+
+
+__all__ = ["Listing"]

--- a/src/jimoty_zero_yen/parser.py
+++ b/src/jimoty_zero_yen/parser.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from html import unescape
+from html.parser import HTMLParser
+from typing import List, Optional
+
+from .models import Listing
+
+ISO_DATE_PATTERNS = (
+    "%Y-%m-%dT%H:%M:%S%z",
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%d",
+)
+
+_PRICE_RE = re.compile(r"(\d+)")
+_ID_RE = re.compile(r"/(?:items/)?([\w-]+)$")
+_SCRIPT_RE = re.compile(
+    r"<script[^>]+type=\"application/ld\+json\"[^>]*>(.*?)</script>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+@dataclass
+class _ParsedItem:
+    url: Optional[str] = None
+    title: Optional[str] = None
+    price_text: Optional[str] = None
+    location: Optional[str] = None
+    posted_at: Optional[str] = None
+    thumbnail: Optional[str] = None
+
+
+class _ListingHTMLParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.items: List[_ParsedItem] = []
+        self._current: Optional[_ParsedItem] = None
+        self._current_field: Optional[str] = None
+        self._buffer: List[str] = []
+        self._depth: int = 0
+
+    # ------------------------------------------------------------------
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
+        attr_dict = {name: (value or "") for name, value in attrs}
+        classes = set(attr_dict.get("class", "").split())
+        data_cy = attr_dict.get("data-cy", "")
+
+        is_item_tag = tag in {"li", "article", "div"}
+        item_condition = (
+            data_cy == "item"
+            or any(cls.startswith("p-items__item") for cls in classes)
+            or attr_dict.get("data-testid") == "item-card"
+        )
+
+        if self._current is None and is_item_tag and item_condition:
+            self._current = _ParsedItem()
+            self._depth = 1
+            return
+
+        if self._current is not None:
+            self._depth += 1
+            if tag == "a" and "href" in attr_dict:
+                self._current.url = attr_dict["href"]
+                self._start_capture("title")
+            elif tag == "span":
+                if (
+                    data_cy == "item-price"
+                    or "p-items-price" in classes
+                    or "p-item__price" in classes
+                ):
+                    self._start_capture("price_text")
+                elif (
+                    data_cy == "item-region"
+                    or "p-items-region" in classes
+                    or "p-item__pref" in classes
+                ):
+                    self._start_capture("location")
+            elif tag == "time":
+                if "datetime" in attr_dict:
+                    self._current.posted_at = attr_dict["datetime"]
+            elif tag == "img" and "src" in attr_dict and not self._current.thumbnail:
+                self._current.thumbnail = attr_dict["src"]
+
+    # ------------------------------------------------------------------
+    def handle_endtag(self, tag: str) -> None:
+        if self._current is None:
+            return
+
+        if self._current_field and tag in {"a", "span"}:
+            text = unescape("".join(self._buffer)).strip()
+            if text:
+                setattr(self._current, self._current_field, text)
+            self._current_field = None
+            self._buffer = []
+            return
+
+        self._depth -= 1
+        if self._depth <= 0:
+            self.items.append(self._current)
+            self._current = None
+            self._current_field = None
+            self._buffer = []
+            self._depth = 0
+
+    # ------------------------------------------------------------------
+    def handle_data(self, data: str) -> None:
+        if self._current is not None and self._current_field:
+            self._buffer.append(data)
+
+    # ------------------------------------------------------------------
+    def _start_capture(self, field: str) -> None:
+        if getattr(self._current, field) is None:
+            self._current_field = field
+            self._buffer = []
+
+
+class JimotyParser:
+    """Parse Jimoty listing search pages into :class:`Listing` objects."""
+
+    def parse_listings(self, html: str) -> List[Listing]:
+        listings = self._parse_from_json_ld(html)
+        if listings:
+            return listings
+        return self._parse_from_dom(html)
+
+    # ------------------------------------------------------------------
+    def _parse_from_json_ld(self, html: str) -> List[Listing]:
+        listings: List[Listing] = []
+        for match in _SCRIPT_RE.finditer(html):
+            data = self._safe_load_json(match.group(1))
+            if not data:
+                continue
+            listings.extend(self._parse_ld_data(data))
+        return listings
+
+    def _parse_ld_data(self, data) -> List[Listing]:
+        if isinstance(data, list):
+            listings: List[Listing] = []
+            for item in data:
+                listings.extend(self._parse_ld_data(item))
+            return listings
+
+        if not isinstance(data, dict):
+            return []
+
+        if data.get("@type") == "ItemList" and "itemListElement" in data:
+            return [self._listing_from_ld_item(item) for item in data["itemListElement"] if item]
+
+        if "@graph" in data and isinstance(data["@graph"], list):
+            listings: List[Listing] = []
+            for entry in data["@graph"]:
+                listings.extend(self._parse_ld_data(entry))
+            return listings
+
+        if data.get("@type") in {"ListItem", "Product", "Offer"}:
+            return [self._listing_from_ld_item(data)]
+
+        return []
+
+    def _listing_from_ld_item(self, data: dict) -> Listing:
+        item = data.get("item") if isinstance(data.get("item"), dict) else data
+        url = item.get("url") or item.get("@id") or data.get("url")
+        title = item.get("name") or data.get("name") or ""
+
+        offers = item.get("offers") or data.get("offers")
+        if isinstance(offers, list):
+            offer = offers[0] if offers else {}
+        elif isinstance(offers, dict):
+            offer = offers
+        else:
+            offer = {}
+
+        price_raw = offer.get("price")
+        price = self._parse_price(price_raw)
+
+        listing_id = self._extract_listing_id(url) or title
+
+        posted_at = None
+        for key in ("datePosted", "availabilityStarts", "startDate"):
+            value = item.get(key) or data.get(key)
+            if isinstance(value, str):
+                posted_at = self._parse_datetime(value)
+                if posted_at:
+                    break
+
+        location = None
+        for key in ("areaServed", "address", "availableAtOrFrom"):
+            value = item.get(key) or data.get(key)
+            if isinstance(value, dict):
+                location = value.get("name") or value.get("addressLocality")
+            elif isinstance(value, str):
+                location = value
+            if location:
+                break
+
+        thumb = None
+        image = item.get("image") or data.get("image")
+        if isinstance(image, list) and image:
+            thumb = image[0]
+        elif isinstance(image, str):
+            thumb = image
+
+        return Listing(
+            id=str(listing_id),
+            title=title.strip(),
+            price=price,
+            url=url,
+            location=location,
+            posted_at=posted_at,
+            thumbnail_url=thumb,
+        )
+
+    # ------------------------------------------------------------------
+    def _parse_from_dom(self, html: str) -> List[Listing]:
+        parser = _ListingHTMLParser()
+        parser.feed(html)
+        listings: List[Listing] = []
+        for item in parser.items:
+            if not (item.url or item.title):
+                continue
+            listing_id = self._extract_listing_id(item.url) or (item.title or "")
+            listings.append(
+                Listing(
+                    id=str(listing_id),
+                    title=(item.title or "").strip(),
+                    price=self._parse_price(item.price_text),
+                    url=item.url or "",
+                    location=item.location,
+                    posted_at=self._parse_datetime(item.posted_at) if item.posted_at else None,
+                    thumbnail_url=item.thumbnail,
+                )
+            )
+        return listings
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _parse_price(value) -> int:
+        if value is None:
+            return 0
+        if isinstance(value, (int, float)):
+            return int(value)
+        match = _PRICE_RE.search(str(value))
+        if match:
+            return int(match.group(1))
+        return 0
+
+    @staticmethod
+    def _parse_datetime(value: str | None) -> datetime | None:
+        if not value:
+            return None
+        for pattern in ISO_DATE_PATTERNS:
+            try:
+                return datetime.strptime(value, pattern)
+            except ValueError:
+                continue
+        return None
+
+    @staticmethod
+    def _safe_load_json(raw: str | None):
+        if not raw:
+            return None
+        raw = raw.strip()
+        if not raw:
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+
+    @staticmethod
+    def _extract_listing_id(url: str | None) -> str | None:
+        if not url:
+            return None
+        match = _ID_RE.search(url)
+        if match:
+            return match.group(1)
+        return None
+
+
+__all__ = ["JimotyParser"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))

--- a/tests/data/sample_listings.html
+++ b/tests/data/sample_listings.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <title>Zero Yen Listings</title>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "item": {
+            "@type": "Product",
+            "@id": "https://jmty.jp/tokyo/sale-fur/article-abcd1",
+            "name": "無料ソファ",
+            "image": "https://images.example.com/sofa.jpg",
+            "offers": {
+              "@type": "Offer",
+              "price": "0",
+              "priceCurrency": "JPY"
+            },
+            "datePosted": "2024-01-05T07:00:00+09:00",
+            "areaServed": {
+              "@type": "AdministrativeArea",
+              "name": "東京都"
+            }
+          }
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "item": {
+            "@type": "Product",
+            "url": "https://jmty.jp/osaka/sale-fur/article-abcd2",
+            "name": "0円ベッド",
+            "image": ["https://images.example.com/bed.jpg"],
+            "offers": {
+              "@type": "Offer",
+              "price": 0,
+              "priceCurrency": "JPY"
+            },
+            "availabilityStarts": "2024-01-05T09:15:00+09:00",
+            "address": {
+              "@type": "PostalAddress",
+              "addressLocality": "大阪府"
+            }
+          }
+        }
+      ]
+    }
+    </script>
+  </head>
+  <body>
+    <ul class="p-items">
+      <li class="p-items__item" data-cy="item">
+        <a href="https://jmty.jp/hokkaido/sale-hom/article-abcd3">炊飯器を無料で譲ります</a>
+        <span class="p-items-price">0円</span>
+        <span class="p-items-region">北海道</span>
+        <time datetime="2024-01-05T10:30:00+09:00">1時間前</time>
+        <img src="https://images.example.com/rice.jpg" alt="炊飯器" />
+      </li>
+    </ul>
+  </body>
+</html>

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from jimoty_zero_yen.cache import ListingCache
+from jimoty_zero_yen.models import Listing
+
+
+class ListingCacheTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.cache_path = Path(self.temp_dir.name) / "cache.json"
+
+    def _listing(self, listing_id: str) -> Listing:
+        return Listing(id=listing_id, title="", price=0, url=f"https://example.com/{listing_id}")
+
+    def test_cache_persists_seen_listings(self) -> None:
+        cache = ListingCache(self.cache_path)
+        self.assertFalse(cache.seen("abc"))
+        self.assertTrue(cache.mark_seen(self._listing("abc")))
+        self.assertTrue(cache.seen("abc"))
+
+        cache = ListingCache(self.cache_path)
+        self.assertTrue(cache.seen("abc"))
+
+    def test_cache_filters_new_entries(self) -> None:
+        cache = ListingCache(self.cache_path)
+        listings = [self._listing("a"), self._listing("b"), self._listing("c")]
+
+        new_listings = cache.filter_new(listings)
+        self.assertEqual([listing.id for listing in new_listings], ["a", "b", "c"])
+
+        additional = [self._listing("b"), self._listing("d")]
+        new_listings = cache.filter_new(additional)
+        self.assertEqual([listing.id for listing in new_listings], ["d"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import unittest
+
+from jimoty_zero_yen.client import JimotyClient
+from jimoty_zero_yen.models import Listing
+
+
+class JimotyClientTests(unittest.TestCase):
+    def test_builds_search_url_with_params(self) -> None:
+        client = JimotyClient(fetcher=lambda url: "")
+        url = client._build_search_url(page=2)
+        self.assertIn("price=0", url)
+        self.assertIn("page=2", url)
+
+    def test_fetches_until_empty_page(self) -> None:
+        pages = []
+
+        def fake_fetch(url: str) -> str:
+            pages.append(url)
+            if len(pages) == 1:
+                return "<html></html>"
+            return ""
+
+        parser_call_order = []
+
+        class FakeParser:
+            def parse_listings(self, html: str):
+                parser_call_order.append(html)
+                if html:
+                    return [Listing(id="1", title="", price=0, url="https://example.com/1")]
+                return []
+
+        client = JimotyClient(parser=FakeParser(), fetcher=fake_fetch)
+        listings = client.fetch_zero_yen_listings(pages=3)
+
+        self.assertEqual(len(listings), 1)
+        self.assertEqual(len(pages), 2)
+        self.assertEqual(len(parser_call_order), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from jimoty_zero_yen.parser import JimotyParser
+
+
+class JimotyParserTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.sample_html = Path("tests/data/sample_listings.html").read_text("utf-8")
+
+    def test_parse_listings_prefers_json_ld(self) -> None:
+        parser = JimotyParser()
+        listings = parser.parse_listings(self.sample_html)
+
+        self.assertEqual(len(listings), 2)
+        first = listings[0]
+        self.assertEqual(first.id, "article-abcd1")
+        self.assertEqual(first.title, "無料ソファ")
+        self.assertEqual(first.price, 0)
+        self.assertEqual(first.location, "東京都")
+        self.assertEqual(first.thumbnail_url, "https://images.example.com/sofa.jpg")
+        self.assertEqual(first.posted_at, datetime(2024, 1, 4, 22, 0, tzinfo=timezone.utc))
+
+    def test_parse_listings_from_dom_when_no_json_ld(self) -> None:
+        parser = JimotyParser()
+        html_without_ld = self.sample_html.replace("type=\"application/ld+json\"", "type=\"text/plain\"")
+        listings = parser.parse_listings(html_without_ld)
+
+        self.assertEqual(len(listings), 1)
+        listing = listings[0]
+        self.assertEqual(listing.id, "article-abcd3")
+        self.assertEqual(listing.title, "炊飯器を無料で譲ります")
+        self.assertEqual(listing.price, 0)
+        self.assertEqual(listing.location, "北海道")
+        self.assertEqual(listing.posted_at, datetime(2024, 1, 5, 1, 30, tzinfo=timezone.utc))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a standard-library based `jimoty_zero_yen` package with data model, HTML/JSON-LD parser, network client, CLI, and persistent cache utilities for tracking free listings
- document usage patterns and note the lack of third-party dependencies while providing a CLI helper and AI integration hints
- supply sample HTML fixtures with unittests that cover parsing, caching, and client pagination logic and include a gitignore for bytecode

## Testing
- python -m unittest discover

------
https://chatgpt.com/codex/tasks/task_e_68cfa6df932c832d9a2b8ab0e52ffb3f